### PR TITLE
Make storage lazy.

### DIFF
--- a/src/LocatorRegistry.php
+++ b/src/LocatorRegistry.php
@@ -40,7 +40,7 @@ class LocatorRegistry implements Registry
     public function getStorage(string $name): Storage
     {
         if (false == $this->container->has($name)) {
-            throw new \InvalidArgumentException(sprintf('The storage with name "%s" does not exist', $id));
+            throw new \InvalidArgumentException(sprintf('The storage with name "%s" does not exist', $name));
         }
 
         return $this->container->get($name);


### PR DESCRIPTION
Problem:  warmup command throws an exception if there is no proper db connection (which is fine for ci stage) and storage is injected to a listener. 

One solution would be to inject yadm registry and get storage at runtime. That works but require more code and additional dependency. Lazy storages solve the problem  